### PR TITLE
Fix WebKit style

### DIFF
--- a/webkit.cpp
+++ b/webkit.cpp
@@ -3,8 +3,8 @@
 namespace western {
 
 enum ShootingHand {
-    kLeft,
-    kRight
+    Left,
+    Right
 };
 
 class Cowboy {

--- a/webkit.cpp
+++ b/webkit.cpp
@@ -14,7 +14,7 @@ public:
     ~Cowboy();
 
     void shoot(std::string who);
-    int getAge() { return m_age; } // minor functions have lower case
+    int age() { return m_age; } // minor functions have lower case
 
 protected:
     void makeBang(const int& howMany);


### PR DESCRIPTION
According to the WebKit coding style:
1. A simple getter should not contain a "get" prefix. Please see https://webkit.org/code-style-guidelines/#names-setter-getter.
2.Enum members should use InterCaps with an initial capital letter. Please see https://webkit.org/code-style-guidelines/#names-enum-members.

