### PR TITLE
Update LLVM and Mozilla files to match clang-format output

### DIFF
--- a/llvm.cpp
+++ b/llvm.cpp
@@ -20,7 +20,8 @@ protected:
   int Age;
 }
 
-Cowboy::Cowboy() : Age(45), GunCount(2) {
+Cowboy::Cowboy()
+    : Age(45), GunCount(2) {
   std::cout << "I am alive!" << std::endl;
 }
 
@@ -59,7 +60,7 @@ void someVeryLongMethod(int param1, int param2, int param3, int param4,
                         int param9, int param10) {
   std::cout << "So long..." << std::endl;
 }
-}
+} // namespace western
 
 using namespace western;
 

--- a/mozilla.cpp
+++ b/mozilla.cpp
@@ -73,8 +73,16 @@ Cowboy::MakeBang(const int& aHowMany)
 }
 
 void
-someVeryLongMethod(int param1, int param2, int param3, int param4, int param5,
-                   int param6, int param7, int param8, int param9, int param10)
+someVeryLongMethod(int param1,
+                   int param2,
+                   int param3,
+                   int param4,
+                   int param5,
+                   int param6,
+                   int param7,
+                   int param8,
+                   int param9,
+                   int param10)
 {
   std::cout << "So long..." << std::endl;
 }


### PR DESCRIPTION
Hello. I cloned and ran the commands described in the README (didn't change anything) to check if the files were still up to date and noticed that LLVM and Mozilla outputs were a little different.

I am no expert on either style, but I guess clang-format must have updated it's configuration.